### PR TITLE
set an algorithm type to rsa256

### DIFF
--- a/Chapter03 and 04/mern-skeleton/server/controllers/auth.controller.js
+++ b/Chapter03 and 04/mern-skeleton/server/controllers/auth.controller.js
@@ -54,7 +54,9 @@ const signout = (req, res) => {
 
 const requireSignin = expressJwt({
   secret: config.jwtSecret,
-  userProperty: 'auth'
+  userProperty: 'auth',
+  algorithms: ['RS256']
+  
 })
 
 const hasAuthorization = (req, res, next) => {


### PR DESCRIPTION
express-jwt requires an argument for the algorithm type otherwise the app crashes