### PR TITLE
a small mistake about parameters in PrivateRoute.js

### DIFF
--- a/Chapter03 and 04/mern-skeleton/client/auth/PrivateRoute.js
+++ b/Chapter03 and 04/mern-skeleton/client/auth/PrivateRoute.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import { Route, Redirect } from 'react-router-dom'
 import auth from './auth-helper'
 
-const PrivateRoute = ({ component: Component, ...rest }) => (
+const PrivateRoute = ({ component: component, ...rest }) => (
   <Route {...rest} render={props => (
     auth.isAuthenticated() ? (
       <Component {...props}/>


### PR DESCRIPTION
I suggest that you should write "{ component: component }" instead of "{ component: Component }". Otherwise the "component" you get from "<"PrivateRouter component={...} />" will be overwritten by "Component" from react. I just find it by console.log(component);