### PR TITLE
Update webpack.config.client.js const config's devtool property 

### DIFF
--- a/Chapter03 and 04/mern-skeleton/webpack.config.client.js
+++ b/Chapter03 and 04/mern-skeleton/webpack.config.client.js
@@ -5,7 +5,7 @@ const CURRENT_WORKING_DIR = process.cwd()
 const config = {
     name: "browser",
     mode: "development",
-    devtool: 'eval-source-map',
+    devtool: 'cheap-module-source-map',
     entry: [
         'webpack-hot-middleware/client?reload=true',
         path.join(CURRENT_WORKING_DIR, 'client/main.js')


### PR DESCRIPTION
""The Content Security Policy (CSP) prevents the evaluation of arbitrary strings as JavaScript to make it more difficult for an attacker to inject unauthorized code on your site.

To solve this issue, avoid using eval(), new Function(), setTimeout([string], ...) and setInterval([string], ...) for evaluating strings.""

Error when using Google Chrome to render the project to the browser--only in development mode--that inhibited the browser's ability to render the UI from webpack bundle.

Switching devtool property of const config in the webpack.config.client.js file resolved the issue for me. I tried to avoid a source-map option that utilized the use of eval().

Source-map options to select for devtool property can be found here: https://webpack.js.org/configuration/devtool/